### PR TITLE
Make it explicit to install the latest cmake from pip

### DIFF
--- a/.github/workflows/spacetime_pytest.yml
+++ b/.github/workflows/spacetime_pytest.yml
@@ -32,7 +32,8 @@ jobs:
             python3.7 python3.7-dev python3.7-venv
         sudo rm /usr/bin/python3
         sudo ln -s python3.7 /usr/bin/python3
-        sudo pip3 install -U numpy pytest setuptools
+        sudo pip3 install -U pip
+        sudo pip3 install -U numpy pytest setuptools cmake
 
     - name: dependency (macos)
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/spacetime_pytest.yml
+++ b/.github/workflows/spacetime_pytest.yml
@@ -39,7 +39,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install python3 numpy
-        pip3 install -U pytest setuptools
+        pip3 install -U pip
+        pip3 install -U pytest setuptools cmake
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/depend/install.sh everything


### PR DESCRIPTION
In #10 it was found that the CI script depends on the [GH action ubuntu 18.04 image](https://github.com/actions/virtual-environments/blob/0ddeb1ac4b2e81f45ba752d49ec5825b77141d40/images/linux/Ubuntu1804-README.md) for cmake 3.16.  The latest version of cmake was not explicitly installed by the script.

While being convenient, it confused someone who is not familiar with the dependencies and GH action.  It's better to make the installation explicit in the CI script.