### PR TITLE
fix: ci build failed on macos-latest

### DIFF
--- a/.github/workflows/spacetime_pytest.yml
+++ b/.github/workflows/spacetime_pytest.yml
@@ -41,9 +41,10 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install python3
+        brew install cmake
         pip3 install -U pip
         pip3 install -U setuptools
-        pip3 install -U numpy pytest cmake
+        pip3 install -U numpy pytest
 
     - name: dependency (manual)
       run: sudo ${GITHUB_WORKSPACE}/contrib/depend/install.sh everything


### PR DESCRIPTION
Added `brew install cmake` replace `pip3 install -U cmake` to fix macos-latest build failed issue.