### PR TITLE
Make build path reflect Python version correctly

### DIFF
--- a/spacetime/Makefile
+++ b/spacetime/Makefile
@@ -21,13 +21,15 @@ NB_ARGS ?=
 CMAKE_ARGS ?=
 VERBOSE ?=
 GDB ?=
-ifeq ($(CMAKE_BUILD_TYPE), Debug)
-	BUILD_PATH ?= build/dbg37
-else
-	BUILD_PATH ?= build/dev37
-endif
 
 PYTHON ?= $(shell which python3)
+PYTHON_VERSION ?= $(shell $(PYTHON) -c 'import sys; print("%d%d" % (sys.version_info.major, sys.version_info.minor))')
+
+ifeq ($(CMAKE_BUILD_TYPE), Debug)
+	BUILD_PATH ?= build/dbg$(PYTHON_VERSION)
+else
+	BUILD_PATH ?= build/dev$(PYTHON_VERSION)
+endif
 
 PYTEST ?= $(shell which py.test-3)
 ifeq ($(PYTEST),)


### PR DESCRIPTION
Fix #29, now Makefile will reflect Python version which it selected on build path.

```
$ make
...
mkdir -p build/dev38 ; \
...
-- Found PythonInterp: /usr/bin/python3.8 (found version "3.8.3") 
-- Found PythonLibs: /usr/lib/libpython3.8.so
...
```