### PR TITLE
fix: specified pybind11 version to v2.6.0

### DIFF
--- a/contrib/depend/install.sh
+++ b/contrib/depend/install.sh
@@ -71,8 +71,8 @@ pybind11() {
   cmakeargs+=("-DCMAKE_BUILD_TYPE=Release")
   cmakeargs+=("-DPYTHON_EXECUTABLE:FILEPATH=`which python3`")
   cmakeargs+=("-DPYBIND11_TEST=OFF")
-  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.5.0} \
-    ${PYBIND_LOCAL:-pybind11-2.5.0} "${cmakeargs[@]}"
+  install ${PYBIND_ORG:-pybind} pybind11 ${PYBIND_BRANCH:-v2.6.0} \
+    ${PYBIND_LOCAL:-pybind11-2.6.0} "${cmakeargs[@]}"
 
 }
 


### PR DESCRIPTION
Because of pybind11 Clang12 issue : https://github.com/pybind/pybind11/pull/2510
We have to update pybind11 version to v2.6.0