### PR TITLE
test: fixed pytest warning

### DIFF
--- a/spacetime/tests/test_celm_selm.py
+++ b/spacetime/tests/test_celm_selm.py
@@ -101,16 +101,16 @@ class CelmTC(unittest.TestCase):
         ce0d.move_neg()
         with self.assertRaisesRegex(
             IndexError,
-            "Celm\(xindex=2\)::move_at\(offset=-1\): xindex = 1 "
-            "outside the interval \[2, 23\)",
+            r"Celm\(xindex=2\)::move_at\(offset=-1\): xindex = 1 "
+            r"outside the interval \[2, 23\)",
         ):
             ce0d.move_neg()
         ce9d = self.ce9.dup
         ce9d.move_pos()
         with self.assertRaisesRegex(
             IndexError,
-            "Celm\(xindex=22\)::move_at\(offset=1\): xindex = 23 "
-            "outside the interval \[2, 23\)",
+            r"Celm\(xindex=22\)::move_at\(offset=1\): xindex = 23 "
+            r"outside the interval \[2, 23\)",
         ):
             ce9d.move_pos()
 
@@ -244,16 +244,16 @@ class SelmTC(unittest.TestCase):
         se0d.move_neg()
         with self.assertRaisesRegex(
             IndexError,
-            "Selm\(xindex=1\)::move_at\(offset=-1\): xindex = 0 "
-            "outside the interval \[1, 24\)",
+            r"Selm\(xindex=1\)::move_at\(offset=-1\): xindex = 0 "
+            r"outside the interval \[1, 24\)",
         ):
             se0d.move_neg()
         se10d = self.se10.dup
         se10d.move_pos()
         with self.assertRaisesRegex(
             IndexError,
-            "Selm\(xindex=23\)::move_at\(offset=1\): xindex = 24 "
-            "outside the interval \[1, 24\)",
+            r"Selm\(xindex=23\)::move_at\(offset=1\): xindex = 24 "
+            r"outside the interval \[1, 24\)",
         ):
             se10d.move_pos()
 

--- a/spacetime/tests/test_grid.py
+++ b/spacetime/tests/test_grid.py
@@ -18,22 +18,22 @@ class GridTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ValueError,
-            "Grid::Grid\(xmin=0, xmax=10, ncelm=0\) invalid argument: "
-            "ncelm smaller than 1",
+            r"Grid::Grid\(xmin=0, xmax=10, ncelm=0\) invalid argument: "
+            r"ncelm smaller than 1",
         ):
             libst.Grid(0, 10, 0)
 
         with self.assertRaisesRegex(
             ValueError,
-            "Grid::Grid\(xmin=10, xmax=10, ncelm=10\) invalid arguments: "
-            "xmin >= xmax",
+            r"Grid::Grid\(xmin=10, xmax=10, ncelm=10\) invalid arguments: "
+            r"xmin >= xmax",
         ):
             libst.Grid(10, 10, 10)
 
         with self.assertRaisesRegex(
             ValueError,
-            "Grid::Grid\(xmin=11, xmax=10, ncelm=10\) invalid arguments: "
-            "xmin >= xmax",
+            r"Grid::Grid\(xmin=11, xmax=10, ncelm=10\) invalid arguments: "
+            r"xmin >= xmax",
         ):
             libst.Grid(11, 10, 10)
 
@@ -43,15 +43,15 @@ class GridTC(unittest.TestCase):
         for s in [0, 1]:
             with self.assertRaisesRegex(
                 ValueError,
-                "Grid::init_from_array\(xloc\) invalid arguments: "
-                "xloc.size\(\)=%d smaller than 2" % s
+                r"Grid::init_from_array\(xloc\) invalid arguments: "
+                r"xloc.size\(\)=%d smaller than 2" % s
             ):
                 libst.Grid(xloc=np.arange(s) * 0.1)
 
         with self.assertRaisesRegex(
             ValueError,
-            "Grid::init_from_array\(xloc\) invalid arguments: "
-            "xloc\[0\]=1 >= xloc\[1\]=0.9"
+            r"Grid::init_from_array\(xloc\) invalid arguments: "
+            r"xloc\[0\]=1 >= xloc\[1\]=0.9"
         ):
             libst.Grid(xloc=np.arange(10, -1, -1) * 0.1)
 

--- a/spacetime/tests/test_solution.py
+++ b/spacetime/tests/test_solution.py
@@ -82,8 +82,8 @@ class SolverTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
             IndexError,
-            "Field::celm_at\(ielm=-1, odd_plane=0\): xindex = 1 "
-            "outside the interval \[2, 23\)",
+            r"Field::celm_at\(ielm=-1, odd_plane=0\): xindex = 1 "
+            r"outside the interval \[2, 23\)",
         ):
             self.sol10.celm(-1, odd_plane=False)
 
@@ -114,8 +114,8 @@ class SolverTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
             IndexError,
-            "Field::celm_at\(ielm=10, odd_plane=0\): xindex = 23 "
-            "outside the interval \[2, 23\)",
+            r"Field::celm_at\(ielm=10, odd_plane=0\): xindex = 23 "
+            r"outside the interval \[2, 23\)",
         ):
             self.sol10.celm(10)
 
@@ -123,8 +123,8 @@ class SolverTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
             IndexError,
-            "Field::selm_at\(ielm=-1, odd_plane=0\): xindex = 0 "
-            "outside the interval \[1, 24\)",
+            r"Field::selm_at\(ielm=-1, odd_plane=0\): xindex = 0 "
+            r"outside the interval \[1, 24\)",
         ):
             self.sol10.selm(-1, odd_plane=False)
 
@@ -155,8 +155,8 @@ class SolverTC(unittest.TestCase):
 
         with self.assertRaisesRegex(
             IndexError,
-            "Field::selm_at\(ielm=11, odd_plane=0\): xindex = 24 "
-            "outside the interval \[1, 24\)",
+            r"Field::selm_at\(ielm=11, odd_plane=0\): xindex = 24 "
+            r"outside the interval \[1, 24\)",
         ):
             self.sol10.selm(11)
 


### PR DESCRIPTION
#28 caused by way which treated raw string literal is different between python2 and python3 interpreter
more detail can check [PEP-414](https://www.python.org/dev/peps/pep-0414/#exclusion-of-raw-unicode-literals)
Therefore `\(` `\)`....`\[`, `\]` such like these string in Regex pattern will be treated as invalid escape sequence,
I figure out two way to fix this issue, 
1. replace `\(` by `\\(`
2. add prefix` r` into Regex pattern explicitly marked with the **raw Unicode**
and I choose 2