### PR TITLE
feat(cmake): enable setting PYTHON_EXECUTABLE in CMakeLists.txt

### DIFF
--- a/spacetime/CMakeLists.txt
+++ b/spacetime/CMakeLists.txt
@@ -13,6 +13,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "Export compile commands")
 
+if(NOT SKIP_PYTHON_EXECUTABLE)
+    find_program(PYTHON_EXECUTABLE python3)
+    message(STATUS "use PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}")
+endif()
+
 option(BUILD_GTESTS "build libst google-test suite" ON)
 option(HIDE_SYMBOL "hide the symbols of python wrapper" OFF)
 option(DEBUG_SYMBOL "add debug information" ON)

--- a/spacetime/Makefile
+++ b/spacetime/Makefile
@@ -22,6 +22,7 @@ CMAKE_ARGS ?=
 VERBOSE ?=
 GDB ?=
 
+SKIP_PYTHON_EXECUTABLE ?= OFF
 PYTHON ?= $(shell which python3)
 PYTHON_VERSION ?= $(shell $(PYTHON) -c 'import sys; print("%d%d" % (sys.version_info.major, sys.version_info.minor))')
 
@@ -97,6 +98,7 @@ $(BUILD_PATH)/Makefile: CMakeLists.txt Makefile
 	cmake $(SPACETIME_ROOT) \
 		-DCMAKE_INSTALL_PREFIX=$(SPACETIME_ROOT) \
 		-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+		-DSKIP_PYTHON_EXECUTABLE=$(SKIP_PYTHON_EXECUTABLE) \
 		-DHIDE_SYMBOL=$(HIDE_SYMBOL) \
 		-DDEBUG_SYMBOL=$(DEBUG_SYMBOL) \
 		-DUSE_CLANG_TIDY=$(USE_CLANG_TIDY) \


### PR DESCRIPTION
As title, or it needs using `-DPYTHON_EXECUTABLE:FILEPATH` to specify PythonInterp.